### PR TITLE
Fix current build issues; explore implementing a CI service

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2.1
+
+jobs:
+  build:
+    macos:
+      xcode: 11.1.0
+
+    environment:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+
+    steps:
+      - checkout
+
+      - run:
+          name: Log CI environment
+          command: ./scripts/log-ci-environment.sh
+
+      - run:
+          name: Install dependencies
+          command: ./scripts/install-ci-dependencies.sh
+
+      - run:
+          name: Build
+          command: |
+            ./build.sh 2>&1 | ts -i
+          no_output_timeout: 120m
+
+      - run:
+          name: Log used space
+          command: du -d 2 -h
+          when: always
+
+      - run:
+          name: Move artifacts
+          command: |
+            mkdir /tmp/artifacts
+            mv *.dmg /tmp/artifacts
+
+      - store_artifacts:
+          path: /tmp/artifacts
+          destination: build

--- a/build.sh
+++ b/build.sh
@@ -10,6 +10,8 @@ export SHELLOPTS
 GNURADIO_BRANCH=3.8.0.0
 GNURADIO_COMMIT_HASH=git:4cc4c74c10411235fb36de58be09022c5573dbd8
 
+GENTOO_MIRROR=https://mirrors.evowise.com/gentoo/distfiles
+
 # default os x path minus /usr/local/bin, which could have pollutants
 export PATH=/usr/bin:/bin:/usr/sbin:/sbin
 
@@ -298,7 +300,7 @@ function unpack() {
     fi
   fi
 
-  D "Looking for an archive matching '${NAME}."
+  D "Looking for an archive matching '${NAME}'"
 
   if [ "git" = "${URL:0:3}" -o "" != "${BRANCH}" ]; then
     I "git repository has been refreshed"
@@ -306,6 +308,7 @@ function unpack() {
     local opts=
     local cmd=
     local Z=
+
     if [ 1 -eq 0 ]; then
       echo 
     elif [ -e ${TMP_DIR}/${NAME}.zip ]; then
@@ -332,7 +335,7 @@ function unpack() {
       cmd=tar
       opts=xpJf
     fi
-    
+
     I "Extracting ${Z} to ${T}"
     rm -Rf ${TMP_DIR}/${T}
     cd ${TMP_DIR} \
@@ -1104,7 +1107,7 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 # 
 (
   P=boost_1_71_0
-  URL=https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/distfiles/${P}.tar.bz2
+  URL="$GENTOO_MIRROR/${P}.tar.bz2"
   CKSUM=sha256:d73a8da01e8bf8c7eda40b4c84915071a8c8a0df4a6734537ddde4a8580524ee
   T=${P}
 
@@ -1295,7 +1298,7 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 # 
 (
   P=Mako-1.0.3
-  URL=https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/distfiles/Mako-1.0.3.tar.gz
+  URL="${GENTOO_MIRROR}/${P}.tar.gz"
   CKSUM=sha256:7644bc0ee35965d2e146dde31827b8982ed70a58281085fac42869a09764d38c
 
   LDFLAGS="${LDFLAGS} $(${PYTHON_CONFIG} --ldflags)"
@@ -1482,7 +1485,7 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 # 
 (
   P=libpng-1.6.37
-  URL="https://mirror.csclub.uwaterloo.ca/gentoo-distfiles/distfiles/${P}.tar.xz"
+  URL="${GENTOO_MIRROR}/${P}.tar.xz"
   CKSUM=sha256:505e70834d35383537b6491e7ae8641f1a4bed1876dbfe361201fc80868d88ca
 
   SKIP_AUTORECONF=true \
@@ -1540,8 +1543,8 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 # 
 (
   P=freetype-2.10.1
-  URL="http://mirror.csclub.uwaterloo.ca/nongnu//freetype/${P}.tar.gz"
-  CKSUM=sha256:3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110
+  URL="${GENTOO_MIRROR}/${P}.tar.xz"
+  CKSUM=sha256:16dbfa488a21fe827dc27eaf708f42f7aa3bb997d745d31a19781628c36ba26f
 
   SKIP_AUTORECONF=yes
   SKIP_LIBTOOLIZE=yes
@@ -1885,7 +1888,7 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
   V=3.34.0-1
   P=adwaita-icon-theme-${V}
   FILENAME=${P}-any.pkg.tar.xz
-  URL="http://mirror.chaoticum.net/arch/extra/os/x86_64/${FILENAME}"
+  URL="http://archive.virtapi.org/packages/a/adwaita-icon-theme/${FILENAME}"
   CKSUM=sha256:0fc25d5b4c345ac2ccc90dbbcd17bcabe4344f35f10d2eac372d7fa86b067749
 
   if [ ! -f ${TMP_DIR}/.${P}.done ]; then
@@ -2000,7 +2003,7 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 #
 (
   P=libf2c-20130927
-  URL=http://mirror.csclub.uwaterloo.ca/gentoo-distfiles/distfiles/libf2c-20130927.zip
+  URL="${GENTOO_MIRROR}/${P}.zip"
   CKSUM=sha256:5dff29c58b428fa00cd36b1220e2d71b9882a658fdec1aa094fb7e6e482d6765
   T=${P}
   BRANCH=""
@@ -2233,11 +2236,12 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 (
   P=uhd
   URL=git://github.com/EttusResearch/uhd.git
-  CKSUM=git:18bc320dc3348346255ab0d33aa319fb2618d7b3
-  BRANCH=18bc320dc3348346255ab0d33aa319fb2618d7b3
+  CKSUM=git:aea0e2de34803d5ea8f25d7cf2fb08f4ab9d43f0
+  BRANCH=aea0e2de34803d5ea8f25d7cf2fb08f4ab9d43f0  # 3.15.0
 
   EXTRA_OPTS="\
     -DENABLE_E300=ON \
+    -DENABLE_X300=OFF \
     -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/usr \
     -DPYTHON_EXECUTABLE=${PYTHON} \
     '-DCMAKE_C_FLAGS=-framework Python' \
@@ -2596,19 +2600,16 @@ fi
   P=log4cpp-${V}
   URL="https://downloads.sourceforge.net/log4cpp/${P}.tar.gz"
   CKSUM=sha256:2cbbea55a5d6895c9f0116a9a9ce3afb86df383cd05c9d6c1a4238e5e5c8f51d
-  MVFROM="log4cpp"
+  T=log4cpp
 
   SKIP_AUTORECONF=true
   SKIP_LIBTOOLIZE=true
-  
+
   build_and_install_autotools \
     ${P} \
     ${URL} \
     ${CKSUM} \
-    ${P} \
-    "" \
-    "" \
-    ${MVFROM}
+    ${T}
 )
 
 
@@ -2967,8 +2968,8 @@ install_soapy_plugin_if_needed "PlutoSDR" "e28e4f5c68c16a38c0b50b9606035f3267a13
 (
   P=gr-soapy
   URL=https://gitlab.com/librespacefoundation/gr-soapy.git
-  CKSUM=git:6c31bc88d5908fd33fbc891271224a8ec782207f
-  BRANCH=6c31bc88d5908fd33fbc891271224a8ec782207f
+  CKSUM=git:a68d05c1f4d069deb7c0efe2a73137ad6cb91c73
+  BRANCH=a68d05c1f4d069deb7c0efe2a73137ad6cb91c73
   T=${P}
 
   # -DCMAKE_PREFIX_PATH=${INSTALL_DIR} \
@@ -3291,8 +3292,8 @@ I created Info.plist
 #
 (
   P=create-dmg
-  URL=http://github.com/andreyvit/create-dmg.git
-  CKSUM=git:5acf22fa87e1b751701f377efddc7429877ecb0a
+  URL=https://github.com/beaugunderson/create-dmg.git
+  CKSUM=git:2ca05eb08f852b07c4e9e15feda257deaf45fba3
   T=${P}
   BRANCH=master
 
@@ -3340,6 +3341,7 @@ I created Info.plist
       --hide-extension GNURadio.app \
       --app-drop-link 412 190 \
       --icon-size 100 \
+      --skip-jenkins \
       ${BUILD_DIR}/GNURadio-${VERSION}.dmg \
       ${TMP_DIR}/${P}/temp \
     || E "failed to create GNURadio-${VERSION}.dmg"

--- a/build.sh
+++ b/build.sh
@@ -1295,7 +1295,7 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 
 #
 # Install mako
-# 
+#
 (
   P=Mako-1.0.3
   URL="${GENTOO_MIRROR}/${P}.tar.gz"
@@ -1328,11 +1328,11 @@ ln -sf ${PYTHON_CONFIG} ${INSTALL_DIR}/usr/bin/python-config
 
 #
 # Install OpenSSL
-# 
+#
 (
-  P=openssl-1.1.0d
-  URL='https://www.openssl.org/source/openssl-1.1.0d.tar.gz'
-  CKSUM=sha256:7d5ebb9e89756545c156ff9c13cf2aa6214193b010a468a3bc789c3c28fe60df
+  P=openssl-1.1.1f
+  URL="https://www.openssl.org/source/${P}.tar.gz"
+  CKSUM=sha256:186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35
 
   SKIP_AUTORECONF=yes \
   SKIP_LIBTOOLIZE=yes \

--- a/scripts/install-ci-dependencies.sh
+++ b/scripts/install-ci-dependencies.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+brew uninstall parallel  # conflicts with moreutils
+
+brew install moreutils
+brew install wget
+
+brew cask install xquartz
+
+PYTHON_VERSION="python-3.7.7-macosx10.9.pkg"
+
+wget "https://www.python.org/ftp/python/3.7.7/$PYTHON_VERSION"
+
+sudo installer -pkg "$PYTHON_VERSION" -target /
+
+# Works around an issue with the submodule defined in the bladeRF repository;
+# git fails to fetch it with a trailing slash but works fine without it.
+git config --global url."https://github.com/analogdevicesinc/no-OS".insteadOf "https://github.com/analogdevicesinc/no-OS/"

--- a/scripts/log-ci-environment.sh
+++ b/scripts/log-ci-environment.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+system_profiler SPSoftwareDataType
+
+clang --version


### PR DESCRIPTION
I wanted to get a new build but it was unclear what the build script would do to my local machine, and I figure CI is a net benefit; here are the results of my exploration. :)

### Build issues fixed

- the previous Gentoo mirror no longer has some of the files needed; I updated to one that does
- the mirror for the Adawaita icons no longer has the file, I updated to one that does
- I updated UHD to 3.15.0, the most recently released version
- I disabled X300 support in UHD to work around https://github.com/EttusResearch/uhd/issues/336 (there's a file in the X300 module that takes 95 minutes to build, likely due to a bug in more recent versions of Apple's `clang`); another approach would be to change optimizations from `-Os` to `-O1` for that specific file
- `log4cpp` failed to build because of the `MVFROM` logic; I'm not sure I understand it correctly but specifying `T` instead of `MVFROM` worked (I think the `T` logic was designed to do the same thing `MVFROM` is for?)
- add workaround for the submodule defined in the bladeRF issue to remove the trailing slash; `git` can't fetch the submodule with the trailing slash present
- the commit specified for `gr-soapy` no longer exists in its repository (they must have rebased/force pushed) but by looking at gitlab I was able to find the same commit with its rewritten hash (`a68d05c1f4d069deb7c0efe2a73137ad6cb91c73`)

### Changes to support CI

- in CI one part of `create-dmg` fails because there's no UI to respond to the macOS permissions dialog box; I'll conditionally disable that piece by passing `--skip-jenkins` to `create-dmg`
- I changed to use my fork of `create-dmg` because `hdiutil detach` apparently doesn't work well in CI environments (my fork adds retries to work around this flakiness)

### CI discussion

I thought this would be a lot easier to get going but it took a number of round-trips to fix existing build issues and figure out what doesn't work in a CI environment. Anyway, it was mostly intended to start a discussion; easy access to GNU Radio is such a cool goal that I couldn't help try to pitch in.

Here are my thoughts:

- Circle allows 25,000 free macOS build credits a month
- one build takes 4 hours and 46 minutes, or 14,300 credits
- you could gate builds on specific commit messages, like only triggering a build if `#build` is passed... but a second rebuild due to a failure would take more than the remaining credits
- additional credits are $15/25,000, which means one unoptimized build is $8.58!
- there's a lot of optimization possible, e.g. caching build output of each library would drastically reduce build time
- the most cost-effective cloud option is probably something like MacStadium ($79/month for a dedicated Mac Mini)

Have you talked to the GNU Radio folks about supporting this project? They may have resources available...

Happy to separate the build fixes into another PR, btw, I think those are valuable even if you're not interested in CI. :)