### PR TITLE
Documentation: Add instructions for trackpad users

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ $ /Library/Frameworks/Python.framework/Versions/3.7/bin/pip install six requests
 $ /Applications/GNURadio.app/Contents/MacOS/usr/lib/uhd/utils/uhd_images_downloader.py
 ```
 
+### Trackpad users
+
+If you're using a trackpad you'll need a way to emulate a middle-click, especially for configuring the GUI blocks. One such tool is [MiddleClick](https://github.com/DaFuqtor/MiddleClick-Catalina).
+
+
 ## Motivation
 
 Some users just do not want to install [MacPorts](https://www.macports.org) only to use GNURadio. We get it. To each their own.


### PR DESCRIPTION
The Qt GUI blocks all use middle-click instead of right-click for their option menus, which means in the absence of additional software they can't be configured using a trackpad... This PR adds a suggestion for that software.