### PR TITLE
Update gr-osmosdr; add gr-fosphor

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2922,9 +2922,9 @@ install_bladerf_bitstream_if_needed "x115" "604b12af77ce4f34db061e9eca4a38d804f6
 #
 (
   P=gr-osmosdr
-  URL=git://github.com/igorauad/gr-osmosdr # Use an alternate tree until upstream catches up with GNUradio 3.8 support.
-  CKSUM=git:f3905d3510dfb3851f946f097a9e2ddaa5fb333b
-  BRANCH=f3905d3510dfb3851f946f097a9e2ddaa5fb333b
+  URL=https://github.com/osmocom/gr-osmosdr.git
+  CKSUM=git:af2fda22b3b3745520ef38e9aaa757484871ee0c
+  BRANCH=af2fda22b3b3745520ef38e9aaa757484871ee0c
   T=${P}
 
   LDFLAGS="${LDFLAGS} $(${PYTHON_CONFIG} --ldflags)" \

--- a/build.sh
+++ b/build.sh
@@ -2948,6 +2948,36 @@ install_bladerf_bitstream_if_needed "x115" "604b12af77ce4f34db061e9eca4a38d804f6
 
 
 #
+# Install gr-fosphor
+#
+(
+  P=gr-fosphor
+  URL=https://github.com/osmocom/gr-fosphor.git
+  CKSUM=git:2d4fe78b43bb67907722f998feeb4534ecb1efa8
+  BRANCH=2d4fe78b43bb67907722f998feeb4534ecb1efa8
+  T=${P}
+
+  LDFLAGS="${LDFLAGS} $(${PYTHON_CONFIG} --ldflags)" \
+  EXTRA_OPTS="\
+    -DCMAKE_MACOSX_RPATH=OLD \
+    -DCMAKE_INSTALL_NAME_DIR=${INSTALL_DIR}/usr/lib \
+    -DCMAKE_INSTALL_PREFIX=${INSTALL_DIR}/usr \
+    -DPYTHON_EXECUTABLE=$(which ${PYTHON}) \
+    -DBoost_NO_BOOST_CMAKE=ON \
+    -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON \
+    -DCMAKE_PREFIX_PATH=${INSTALL_DIR} \
+    -DCMAKE_IGNORE_PATH=/usr/local/lib;/usr/local/include \
+    ${TMP_DIR}/${T}" \
+  build_and_install_cmake \
+    ${P} \
+    ${URL} \
+    ${CKSUM} \
+    ${T} \
+    ${BRANCH}
+)
+
+
+#
 # Install our supported Soapy plugins.
 #
 install_soapy_plugin_if_needed "BladeRF"   "1c1e8aaba5e8ee154b34c6c3b17743d1c9b9a1ea"


### PR DESCRIPTION
A big part of the reason I started looking into this project was that I could not for the life of me figure out how to get a version of `osmocom_fft` with fosphor support that didn't just crash at launch.

This PR does two things:

- moves back to the main osmosdr repo now that 3.8 support is there
- adds `gr-fosphor` so that the `osmocom_fft` included with osmosdr can find the fosphor library when `-F` is used